### PR TITLE
feat(ios): use displayName as CXHandle value for readable CallKit recents

### DIFF
--- a/ios/Sources/CapacitorTwilioVoicePlugin/CapacitorTwilioVoicePlugin.swift
+++ b/ios/Sources/CapacitorTwilioVoicePlugin/CapacitorTwilioVoicePlugin.swift
@@ -377,6 +377,8 @@ public class CapacitorTwilioVoicePlugin: CAPPlugin, CAPBridgedPlugin, PushKitEve
             return
         }
 
+        let displayName = call.getString("displayName")
+
         checkRecordPermission { [weak self] permissionGranted in
             guard permissionGranted else {
                 call.reject("Microphone permission not granted")
@@ -388,6 +390,7 @@ public class CapacitorTwilioVoicePlugin: CAPPlugin, CAPBridgedPlugin, PushKitEve
                                          handle: to,
                                          to: to,
                                          isSystemInitiated: false,
+                                         displayName: displayName,
                                          completion: { success in
                                             if success {
                                                 call.resolve(["success": true, "callSid": uuid.uuidString])
@@ -841,7 +844,8 @@ public class CapacitorTwilioVoicePlugin: CAPPlugin, CAPBridgedPlugin, PushKitEve
                                                          isSystemInitiated: isSystemInitiated,
                                                          displayName: displayName)
 
-        let callHandle = CXHandle(type: .generic, value: handle)
+        let handleValue = (displayName?.isEmpty == false ? displayName! : handle)
+        let callHandle = CXHandle(type: .generic, value: handleValue)
         let startCallAction = CXStartCallAction(call: uuid, handle: callHandle)
         let transaction = CXTransaction(action: startCallAction)
 
@@ -873,7 +877,8 @@ public class CapacitorTwilioVoicePlugin: CAPPlugin, CAPBridgedPlugin, PushKitEve
     private func reportIncomingCall(from: String, niceName: String, uuid: UUID) {
         guard let provider = callKitProvider else { return }
 
-        let callHandle = CXHandle(type: .generic, value: from)
+        let handleValue = niceName.isEmpty ? from : niceName
+        let callHandle = CXHandle(type: .generic, value: handleValue)
         let callUpdate = CXCallUpdate()
 
         callUpdate.remoteHandle = callHandle

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -129,6 +129,9 @@ export interface CapacitorTwilioVoicePlugin {
    *
    * @param options - Configuration object
    * @param options.to - Phone number (E.164 format) or Twilio client identifier to call
+   * @param options.displayName - Optional human-readable name used as the
+   *   iOS CXHandle value so Phone.app Recents renders a readable label
+   *   instead of the raw `to` identity.
    * @returns Promise that resolves with success status and call SID
    * @returns success - Whether the call was initiated successfully
    * @returns callSid - Unique identifier for this call (if successful)
@@ -141,13 +144,14 @@ export interface CapacitorTwilioVoicePlugin {
    * });
    * console.log('Call SID:', result.callSid);
    *
-   * // Call another Twilio client
+   * // Call another Twilio client with a readable name for CallKit Recents
    * await CapacitorTwilioVoice.makeCall({
-   *   to: 'client:alice'
+   *   to: 'client:alice',
+   *   displayName: 'Alice Smith'
    * });
    * ```
    */
-  makeCall(options: { to: string }): Promise<{ success: boolean; callSid?: string }>;
+  makeCall(options: { to: string; displayName?: string }): Promise<{ success: boolean; callSid?: string }>;
 
   /**
    * Accept an incoming call.


### PR DESCRIPTION
## Problem

The plugin currently sets `CXHandle(type: .generic, value: <raw identity>)` for both incoming and outgoing calls. The live incoming-call UI uses `localizedCallerName` correctly, but **iOS Phone.app Recents / Call History displays `CXHandle.value`**, not `localizedCallerName`. For apps using Twilio client identifiers (UUIDs, opaque strings) this means every call shows up as `client:{uuid}` in the system call history, which is essentially unreadable for end users.

We hit this in a production app (Twilio client identities are UUIDs) and confirmed the root cause against Apple Developer Forums. Notably, `CXCallDirectoryExtension` — the commonly-cited workaround — is typed as `CXCallDirectoryPhoneNumber` (`Int64`) and cannot register generic handle values, so that path is closed for apps like ours.

## Changes

Three small additions, fully backward compatible:

1. **`makeCall` accepts an optional `displayName`**. Apps that want readable Recents entries can now pass a human-readable name alongside `to`. Apps that don't pass one keep the current behavior.

2. **`performStartCallAction` prefers `displayName` as the `CXHandle` value** when present, falls back to the raw `handle` otherwise.

3. **`reportIncomingCall` prefers `niceName` as the `CXHandle` value** (the already-resolved name from the `CapacitorTwilioCallerName` custom parameter) when present, falls back to `from` otherwise. `localizedCallerName` continues to be set to `niceName` — the live-call UI behavior is unchanged.

Closes https://github.com/Cap-go/capacitor-twilio-voice/issues/46

## Before / after

**Before** (Twilio client identity calls):
- iOS Phone.app Recents shows `client:3f2a8d1e-...`

**After**:
- iOS Phone.app Recents shows the human name (e.g. `Alice Smith`)
- Live call UI unchanged (already worked)

## Compatibility

- **API**: `displayName` is optional. Existing callers of `makeCall({ to })` are unaffected.
- **Incoming calls**: the new fallback (`niceName.isEmpty ? from : niceName`) degrades to the old behavior when no `CapacitorTwilioCallerName` custom parameter is set, so apps not using that param see no change.
- **Outgoing calls**: same story — apps that don't pass `displayName` get the previous behavior.
- **Callback-from-Recents**: tapping a Recents entry with a generic-type handle doesn't reliably round-trip through `CXStartCallAction` anyway (documented in [react-native-callkeep #349](https://github.com/react-native-webrtc/react-native-callkeep/issues/349)). This PR doesn't regress an already-broken path.

## Why not a `CXCallDirectoryExtension`

`CXCallDirectoryExtensionContext.addIdentificationEntry(withNextSequentialPhoneNumber:label:)` is typed as `Int64`. It only accepts E.164 phone numbers. It cannot register `client:{uuid}`, `.generic`, or `.emailAddress` handle values. Confirmed by Apple DTS on DevForum threads [54096](https://developer.apple.com/forums/thread/54096), [656720](https://developer.apple.com/forums/thread/656720), [751572](https://developer.apple.com/forums/thread/751572), and [765571](https://developer.apple.com/forums/thread/765571).

Apps like WhatsApp, Signal, Instagram solve this by writing `CNContact` records to the user's device Contacts (gated by the Contacts write permission). That's beyond what a plugin can or should do — app developers can still do that themselves on top of this change if they want the full treatment. For apps that don't want to touch the user's address book, the `displayName` pass-through in this PR is the cheapest path to readable Recents entries.

## Android

Android has an analogous issue in `ConnectionService` call-log display, but Android uses a separate code path and isn't included in this PR. Happy to follow up with an Android PR using the same pattern if this direction is accepted.

## Testing

Verified on a production Capacitor app (iOS 18 + iOS 26) before the same change was extracted into this PR:
- Outgoing call with `displayName` → Recents entry shows the name
- Incoming call with `CapacitorTwilioCallerName` custom param → Recents entry shows the name
- Outgoing call without `displayName` → Recents entry shows raw `to` (unchanged from current behavior)
- Incoming call without `CapacitorTwilioCallerName` → Recents entry shows raw `from` (unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `displayName` parameter to call initiation. When provided, the display name appears in the iOS phone app's call interface and recents list, providing a human-readable identifier instead of just the phone number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->